### PR TITLE
Template driven

### DIFF
--- a/src/app/household.ts
+++ b/src/app/household.ts
@@ -8,7 +8,7 @@ export class Household {
   accommodation: Accommodation;
   songs: string[];
   drinks: string[];
-  dietaryRestrictions: string[];
+  dietaryRestrictions: string;
 
   constructor(data: {[field: string]: any})  {
     this.name = data.name || '';

--- a/src/app/member.ts
+++ b/src/app/member.ts
@@ -19,6 +19,7 @@ export class Member {
     this.plusOne = data.PlusOne || null;
     this.dietaryRestrictions = data.dietaryRestrictions || [];
   }
+
 }
 
 export enum MemberType {

--- a/src/app/rsvp-form/rsvp-form.component.html
+++ b/src/app/rsvp-form/rsvp-form.component.html
@@ -1,35 +1,35 @@
 <mat-card [ngSwitch]="state">
   <ng-container *ngSwitchCase=0>
-    <ng-container *ngIf="household | async as h">
-      {{"Hey " + h?.greeting + "!"}}
+    <ng-container *ngIf="household">
+      {{"Hey " + household.greeting + "!"}}
       <mat-vertical-stepper [linear]="false" #stepper>
-        <mat-step [stepControl]="attendance">
-          <form [formGroup]="attendance">
+        <mat-step>
+          <form>
             <ng-template matStepLabel>Who's able to make it?</ng-template>
             <mat-list>
-              <mat-list-item *ngFor="let member of h?.members">
-                <mat-checkbox formControlName={{member.id}}>
+              <mat-list-item *ngFor="let member of household.members">
+                <mat-checkbox [(ngModel)]="member.isComing" name="member.id">
                   {{member.first + ' ' + member.last}}
                 </mat-checkbox>
               </mat-list-item>
             </mat-list>
           </form>
         </mat-step>
-        <mat-step *ngIf="h?.allowedPlusOnes()" [stepControl]="plusOnes">
-          <form [formGroup]="plusOnes">
+        <mat-step *ngIf="household.allowedPlusOnes()">
+          <form>
             <ng-template matStepLabel>Anyone Bringing a Plus One?</ng-template>
             <mat-list>
-              <ng-container *ngFor="let member of h?.members">
-                <ng-container *ngIf="member.allowedPlusOne" [formGroup]="plusOnes.controls[member.id]">
-                  <mat-checkbox formControlName="isComing" #is>
+              <ng-container *ngFor="let member of household.members">
+                <ng-container *ngIf="member.allowedPlusOne">
+                  <mat-checkbox (change)="togglePlusOne($event, member)" [disabled]="!member.isComing">
                    {{member.first + ' ' + member.last}}
                   </mat-checkbox>
-                  <ng-container>
+                  <ng-container *ngIf="!!member.plusOne">
                     <mat-form-field>
-                      <input matInput placeholder="First" formControlName="plusOneFirst">
+                      <input matInput placeholder="First" [(ngModel)]="member.plusOne.first" name="first">
                     </mat-form-field>
                     <mat-form-field>
-                      <input matInput placeholder="Last" formControlName="plusOneLast">
+                      <input matInput placeholder="Last" [(ngModel)]="member.plusOne.last" name="last">
                     </mat-form-field>
                   </ng-container>
                 </ng-container>
@@ -37,15 +37,15 @@
             </mat-list>
           </form>
         </mat-step>
-        <mat-step [stepControl]="personalRequests">
-          <form [formGroup]="personalRequests">
+        <mat-step>
+          <form>
             <ng-template matStepLabel>Tell us some stuff we don't know</ng-template>
             <p>
               We will be providing group camping nearby for anyone and everyone coming to party with us.
               It will probably be about 20 minutes away from the reception, and cost about $10 a person.
               Would you be interested in that?
             </p>
-            <mat-radio-group class="radio-list" formControlName="accommodation">
+            <mat-radio-group class="radio-list" [(ngModel)]="household.accommodation" name="accommodation">
               <mat-radio-button class="radio-button" [value]="'camping'">
                 Camping is my favourite, I'm a greasy bear
               </mat-radio-button>
@@ -62,7 +62,7 @@
               They also have a great taste in music. Unfortunately, concessions must be made for people with less gifted ear holes.
               Any songs in particular you think would be perfect for the occasion?
             </p>
-            <app-chip-list formControlName="songs" [placeholder]="'Song Requests'"></app-chip-list>
+            <app-chip-list [(ngModel)]="household.songs" name="songs" [placeholder]="'Song Requests'"></app-chip-list>
             <br>
             <p>
               There will of course be a toonie bar serving liquid dancing shoes.
@@ -70,7 +70,7 @@
               But nobody wants the Bride and Groom to be the only ones with a drink in their hands.
               What's your favourite concoction? (If its popular among others, we might just include it)
             </p>
-            <app-chip-list formControlName="drinks" [placeholder]="'Drink Requests'"></app-chip-list>
+            <app-chip-list [(ngModel)]="household.drinks" name="drinks" [placeholder]="'Drink Requests'"></app-chip-list>
             <p>
               Lets be honest, we all know that the low buck liquor and the free food are some of the biggest draws to a well executed wedding.
               }
@@ -79,9 +79,9 @@
               This is your chance to stand up and say NO to peanuts, meat or any other ingredient that doesn't need to be there.
               We salute your dietary needs, and so do our caterers!
             </p>
-            <ng-container *ngFor="let member of h?.members">
-              {{member.first}}<app-chip-list formControlName="{{member.id}}" [placeholder]="'Dietary Restrictions'"></app-chip-list>
-            </ng-container>
+              <mat-form-field>
+                <textarea matInput placeholder="Dietary Restrictions" [(ngModel)]="household.dietaryRestrictions" name="dietaryRestrictions"></textarea>
+              </mat-form-field>
           </form>
         </mat-step>
         <mat-step>

--- a/src/app/rsvp-form/rsvp-form.component.ts
+++ b/src/app/rsvp-form/rsvp-form.component.ts
@@ -3,7 +3,8 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import { Household } from '../household';
 import { FirestoreService } from '../firestore.service';
 import { Observable } from 'rxjs';
-import { MatSnackBar } from '@angular/material';
+import {MatCheckboxChange, MatSnackBar} from '@angular/material';
+import {Member, PlusOne} from '../member';
 
 enum State {
   success,
@@ -24,26 +25,25 @@ export class RsvpFormComponent implements OnInit {
   plusOnes: FormGroup;
   personalRequests: FormGroup;
 
-  household: Observable<Household>;
+  household: Household;
 
   constructor(private fb: FormBuilder,
               private storage: FirestoreService,
               private snackBar: MatSnackBar) { }
 
   ngOnInit() {
-    this.household = this.storage.getHousehold('fleetwoodmac');
-    this.household.subscribe((household: Household) => {
-      console.log(household);
-      this.rsvpForm = this.buildRSVPForm(household);
+    this.storage.getHousehold('fleetwoodmac').subscribe((household: Household) => {
+      //   console.log(household);
+      this.household = household;
       this.state = State.success;
-    },
-    error => {
-      this.state = State.error;
-      this.snackBar.open(error.message, 'Error',
-        {
-        duration: 2000,
+      },
+      error => {
+        this.state = State.error;
+        this.snackBar.open(error.message, 'Error',
+          {
+          duration: 2000,
+        });
       });
-    });
   }
 
   buildRSVPForm(household: Household): FormGroup {
@@ -99,8 +99,11 @@ export class RsvpFormComponent implements OnInit {
     return this.fb.group([this.attendance, this.plusOnes, this.personalRequests]);
   }
 
-  togglePlusOne(hasPlusOne: string , memberId: string) {
-    // const control = this.fb.control({value: });
-    // this.plusOnes.addControl(`${memberId}-plusone`, control)
+  togglePlusOne($event: MatCheckboxChange, member: Member) {
+    if ($event.checked) {
+      member.plusOne = new PlusOne('', {parentId: member.id});
+    } else {
+      member.plusOne = null;
+    }
   }
 }

--- a/src/app/rsvp-form/rsvp-form.component.ts
+++ b/src/app/rsvp-form/rsvp-form.component.ts
@@ -20,11 +20,6 @@ enum State {
 export class RsvpFormComponent implements OnInit {
   state: State = State.loading;
 
-  rsvpForm: FormGroup;
-  attendance: FormGroup;
-  plusOnes: FormGroup;
-  personalRequests: FormGroup;
-
   household: Household;
 
   constructor(private fb: FormBuilder,
@@ -33,7 +28,6 @@ export class RsvpFormComponent implements OnInit {
 
   ngOnInit() {
     this.storage.getHousehold('fleetwoodmac').subscribe((household: Household) => {
-      //   console.log(household);
       this.household = household;
       this.state = State.success;
       },
@@ -44,59 +38,6 @@ export class RsvpFormComponent implements OnInit {
           duration: 2000,
         });
       });
-  }
-
-  buildRSVPForm(household: Household): FormGroup {
-
-    // Build Attendance Controls
-    const attendanceControls = household.members.reduce((controls, member) => {
-      controls[member.id] = this.fb.control(member.isComing);
-      return controls;
-    }, {});
-
-    this.attendance = this.fb.group(attendanceControls);
-
-    // Build Plus One Controls
-    const plusOneControls = household.members.reduce((controlGroups, member) => {
-      if (member.allowedPlusOne) {
-        const memberPlusOneControls = this.fb.group({
-          isComing: this.fb.control({value: !!member.plusOne, disabled: member.isComing}),
-          plusOneFirst: this.fb.control(member.plusOne ? member.plusOne.first : ''),
-          plusOneLast: this.fb.control(member.plusOne ? member.plusOne.last : '')
-        });
-        console.log(memberPlusOneControls);
-        controlGroups[member.id] = memberPlusOneControls;
-      }
-      return controlGroups;
-    }, {});
-    this.plusOnes = this.fb.group(plusOneControls);
-
-    // Build Personal Requests controls
-    const personalRequestControls = household.members.reduce((controls, member) => {
-      controls[member.id] = this.fb.control(member.dietaryRestrictions);
-      return controls;
-    }, {
-      accommodation: this.fb.control(household.accommodation),
-      songs: this.fb.control(household.songs),
-      drinks: this.fb.control(household.drinks)
-    });
-    this.personalRequests = this.fb.group(personalRequestControls);
-
-    // Enable or Disable controls based on Attendance
-    for (const controlKey in attendanceControls) {
-      if (attendanceControls.hasOwnProperty(controlKey)) {
-        attendanceControls[controlKey].valueChanges.subscribe((isComing: boolean) => {
-          // Enable/Disable Plus One Control
-          if (plusOneControls.hasOwnProperty(controlKey)) {
-            // If not isComing, plus one option should be disabled
-            const control = plusOneControls[controlKey];
-            isComing ? control.enable() : control.disable();
-          }
-        });
-      }
-    }
-
-    return this.fb.group([this.attendance, this.plusOnes, this.personalRequests]);
   }
 
   togglePlusOne($event: MatCheckboxChange, member: Member) {


### PR DESCRIPTION
### Problem:
Maintaining form functionality asynchronously was becoming an unholy mess for such a simple form

### Solution:
Keep a static, mutable reference to the `household`, and update that model using two-way bindings with `ngModel`. This will make form submission easy, and given I'm using Default change detection,  the template will update just fine for disabling/enabling + showing/hiding controls based on other form values.
 - This solution is not scalable, and could potentially drain performance if used at a larger scale. It does however keep form logic manageable. 

### Alternatives: 
- I could (and should) break this form into several smaller components. Think 1 component for each step of the form. Doing this, I could go back to a Reactive form approach and hopefully reduce some of the apparent complexity by isolating different parts of the form. **This might be my next experiment**
